### PR TITLE
Fix @autowired field injection under SWC / native class fields / multi-bundle

### DIFF
--- a/packages/ironbean/src/classComponent.ts
+++ b/packages/ironbean/src/classComponent.ts
@@ -5,6 +5,7 @@ import {
     constants,
     Container,
     getAllPropertyNames,
+    installInstanceAccessors,
     Instance,
     isContext,
     Scope,
@@ -70,6 +71,7 @@ export class ClassComponent<T extends any> extends Component<T> {
         const params = container.getDependencyList(this.getConstructDependencyList());
         const Class = this._Class as TNormalClass<T>;
         const instance = new Class(...params);
+        installInstanceAccessors(instance, Class.prototype);
         // @ts-ignore
         Reflect.defineMetadata(constants.componentContainer, container, instance);
 

--- a/packages/ironbean/src/component.ts
+++ b/packages/ironbean/src/component.ts
@@ -11,6 +11,7 @@ import {
     DependencyComponent,
     DependencyToken,
     IFactory,
+    installInstanceAccessors,
     Instance,
     LazyComponent,
     LazyToken,
@@ -145,6 +146,9 @@ export class Factory<T> implements IConstructable<T> {
         const instance = this.constructInstance(container);
         if (instance instanceof Object) {
             Reflect.defineMetadata(constants.componentContainer, container, instance);
+            if (instance.constructor) {
+                installInstanceAccessors(instance, instance.constructor.prototype);
+            }
         }
 
         return new Instance(instance);

--- a/packages/ironbean/src/useDefClassFiedsHack.ts
+++ b/packages/ironbean/src/useDefClassFiedsHack.ts
@@ -1,4 +1,5 @@
-const propOverridesSymbol = Symbol()
+// Shared across bundled copies so marks are visible between bundle layers.
+const propOverridesSymbol = Symbol.for("ironbean.useDefineForClassFields.propertyOverrides");
 export const defineProperty = Object.defineProperty;
 Object.defineProperty = function(o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>): any {
     if (!isOverwritten(o, p)) {
@@ -24,4 +25,44 @@ export function markAsOverwrittenDefineProperty(o: any, p: string | number | sym
         o[propOverridesSymbol] = new Set();
     }
     o[propOverridesSymbol].add(p);
+}
+
+export function getOverriddenProps(prototype: any): Set<string | number | symbol> {
+    const result = new Set<string | number | symbol>();
+    let current = prototype;
+    while (current) {
+        const set: Set<string | number | symbol> | undefined = current[propOverridesSymbol];
+        if (set) {
+            set.forEach(p => result.add(p));
+        }
+        current = Object.getPrototypeOf(current);
+    }
+    return result;
+}
+
+// Re-install marked prototype accessors on the instance after construction, for
+// targets where the field initializer shadows them with an own property.
+export function installInstanceAccessors(instance: any, ClassProto: any): void {
+    if (!ClassProto) return;
+    const marks = getOverriddenProps(ClassProto);
+    if (marks.size === 0) return;
+    marks.forEach(propName => {
+        try {
+            let proto = ClassProto;
+            let protoDescriptor: PropertyDescriptor | undefined = undefined;
+            while (proto) {
+                protoDescriptor = Object.getOwnPropertyDescriptor(proto, propName);
+                if (protoDescriptor && protoDescriptor.get) break;
+                protoDescriptor = undefined;
+                proto = Object.getPrototypeOf(proto);
+            }
+            if (!protoDescriptor) return;
+            const existing = Object.getOwnPropertyDescriptor(instance, propName);
+            if (existing) {
+                if (!existing.configurable) return;
+                delete instance[propName];
+            }
+            defineProperty(instance, propName, protoDescriptor);
+        } catch (e) {}
+    });
 }

--- a/packages/ironbean/test/useDefClassFiedsHack.spec.ts
+++ b/packages/ironbean/test/useDefClassFiedsHack.spec.ts
@@ -1,0 +1,96 @@
+import {
+    ApplicationContext,
+    autowired,
+    component,
+    destroyContext,
+    getBaseApplicationContext,
+} from "../src";
+import {
+    defineProperty,
+    getOverriddenProps,
+    installInstanceAccessors,
+} from "../src/useDefClassFiedsHack";
+
+// Reproduces the native class-field emit (SWC / ES2022+ targets): an own
+// `value: undefined` property placed on the instance during construction that
+// shadows the @autowired prototype accessor. We emulate it by defining that
+// property inside the constructor via the saved-original `defineProperty`.
+describe("installInstanceAccessors (native class field / SWC scenario)", () => {
+    let applicationContext: ApplicationContext;
+
+    beforeEach(() => {
+        applicationContext = getBaseApplicationContext();
+    });
+
+    afterEach(() => {
+        destroyContext();
+    });
+
+    it("propOverridesSymbol is a shared global registry (multi-bundle safe)", () => {
+        expect(Symbol.for("ironbean.useDefineForClassFields.propertyOverrides"))
+            .toBe(Symbol.for("ironbean.useDefineForClassFields.propertyOverrides"));
+    });
+
+    it("resolves an @autowired field shadowed by a native-field own property (ClassComponent path)", () => {
+        @component
+        class Engine {
+            run() { return "vroom"; }
+        }
+
+        @component
+        class Car {
+            @autowired declare engine: Engine;
+
+            constructor() {
+                // emulate `engine;` native class field shadowing the accessor
+                defineProperty(this, "engine", {
+                    value: undefined,
+                    writable: true,
+                    enumerable: true,
+                    configurable: true,
+                });
+            }
+        }
+
+        const car = applicationContext.getBean(Car);
+
+        expect(car.engine).toBeInstanceOf(Engine);
+        expect(car.engine.run()).toBe("vroom");
+        expect(car.engine).toBe(applicationContext.getBean(Engine));
+    });
+
+    it("getOverriddenProps walks the prototype chain", () => {
+        @component
+        class Base {
+            @autowired declare a: Base;
+        }
+
+        @component
+        class Derived extends Base {
+            @autowired declare b: Base;
+        }
+
+        const props = getOverriddenProps(Derived.prototype);
+        expect(props.has("a")).toBe(true);
+        expect(props.has("b")).toBe(true);
+    });
+
+    it("is a no-op when there is nothing to restore", () => {
+        class Plain {}
+        const instance = new Plain();
+        expect(() => installInstanceAccessors(instance, Plain.prototype)).not.toThrow();
+    });
+
+    it("does not break the already-working case (no shadow present)", () => {
+        @component
+        class Wheel {}
+
+        @component
+        class Bike {
+            @autowired declare wheel: Wheel;
+        }
+
+        const bike = applicationContext.getBean(Bike);
+        expect(bike.wheel).toBeInstanceOf(Wheel);
+    });
+});


### PR DESCRIPTION
Closes #66

## Background

`@autowired` installs an accessor on the class prototype, and `useDefClassFiedsHack` patches `Object.defineProperty` so the class-field initializer doesn't shadow it. That covers `tsc` and SWC at `useDefineForClassFields: false`, but not:

1. **Native class-field syntax** (ES2022+ targets) — the engine defines the field with internal semantics, so there's no `defineProperty` call to intercept and the field shadows the accessor with `undefined`.
2. **Multiple bundled copies** (Next.js App Router layers, etc.) — each copy makes its own `Symbol()` registry, so marks from one layer are invisible to another.

## Fix

- Re-install the marked prototype accessors directly on each instance right after construction (`ClassComponent.construct` and `Factory.construct`). This works regardless of how the field was emitted.
- Share the override registry across bundled copies via `Symbol.for(...)`.

Additive and no API change: where the existing path already prevented the shadow, the post-construction install is an idempotent redefine of the same accessor.

## Note

One remaining gap this can't fix from inside the library: an `@autowired` field read **inside the class's own constructor body** under native class fields — the field-init runs before any library hook. The 1.0.23 README already documents the `declare` modifier as the fix for that case.

## Tested

- Existing suite green on both targets (es5 + es6).
- New `useDefClassFiedsHack.spec.ts` reproduces the native-field shadow deterministically and asserts the field resolves.
- Verified in a Next.js 15.5 + SWC app (~200 field-injection sites), including SSR.