### PR TITLE
CI matrix - testy per TS target / class-field emit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,27 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # všechny dimenze v `include` jinak GA zmerguje rows do jedné combinace
+      # ironbean: per TS target a class-field emit (useDefineForClassFields),
+      # ostatní balíčky mají vlastní jednotný test:no-watch
       matrix:
-        node-version: [16.x]
-        # ironbean: per TS target a class-field emit (useDefineForClassFields),
-        # ostatní balíčky mají vlastní jednotný test:no-watch
         include:
-          - package: ironbean
-            script: test:es5
-          - package: ironbean
-            script: test:es6
-          - package: ironbean
-            script: test:es2022
-          - package: ironbean
-            script: test:es2022-define
-          - package: ironbean-jasmine
-            script: test:no-watch
-          - package: ironbean-jest
-            script: test:no-watch
-          - package: ironbean-react
-            script: test:no-watch
-          - package: ironbean-react-router
-            script: test:no-watch
+          - {package: ironbean, script: test:es5, node-version: 16.x}
+          - {package: ironbean, script: test:es6, node-version: 16.x}
+          - {package: ironbean, script: test:es2022, node-version: 16.x}
+          - {package: ironbean, script: test:es2022-define, node-version: 16.x}
+          - {package: ironbean-jasmine, script: test:no-watch, node-version: 16.x}
+          - {package: ironbean-jest, script: test:no-watch, node-version: 16.x}
+          - {package: ironbean-react, script: test:no-watch, node-version: 16.x}
+          - {package: ironbean-react-router, script: test:no-watch, node-version: 16.x}
     defaults:
       run:
         working-directory: ./packages/${{ matrix.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,36 @@ on:
       - ironbean@*
       - ironbean-react@*
       - ironbean-jasmine@*
+      - ironbean-jest@*
       - ironbean-react-router@*
 
 jobs:
-  release:
+  test:
+    name: test ${{ matrix.package }} / ${{ matrix.script }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        package: [ironbean, ironbean-jasmine, ironbean-jest, ironbean-react, ironbean-react-router]
         node-version: [16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        # ironbean: per TS target a class-field emit (useDefineForClassFields),
+        # ostatní balíčky mají vlastní jednotný test:no-watch
+        include:
+          - package: ironbean
+            script: test:es5
+          - package: ironbean
+            script: test:es6
+          - package: ironbean
+            script: test:es2022
+          - package: ironbean
+            script: test:es2022-define
+          - package: ironbean-jasmine
+            script: test:no-watch
+          - package: ironbean-jest
+            script: test:no-watch
+          - package: ironbean-react
+            script: test:no-watch
+          - package: ironbean-react-router
+            script: test:no-watch
     defaults:
       run:
         working-directory: ./packages/${{ matrix.package }}
@@ -30,9 +50,26 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build
-    - run: npm run test:no-watch
-    - name: Setum npm credentiels
-      run: |
-        echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}' > .npmrc
-        cat .npmrc
+    - run: npm run ${{ matrix.script }}
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ironbean, ironbean-jasmine, ironbean-jest, ironbean-react, ironbean-react-router]
+        node-version: [16.x]
+    defaults:
+      run:
+        working-directory: ./packages/${{ matrix.package }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build
+    - name: Setup npm credentials
+      run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}' > .npmrc
     - run: npm run release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,27 @@ on:
 
 jobs:
   tests:
+    name: ${{ matrix.package }} / ${{ matrix.script }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        package: [ironbean, ironbean-jasmine, ironbean-jest]
         node-version: [16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        # ironbean: per TS target a class-field emit (useDefineForClassFields),
+        # ostatní balíčky mají vlastní jednotný test:no-watch
+        include:
+          - package: ironbean
+            script: test:es5
+          - package: ironbean
+            script: test:es6
+          - package: ironbean
+            script: test:es2022
+          - package: ironbean
+            script: test:es2022-define
+          - package: ironbean-jasmine
+            script: test:no-watch
+          - package: ironbean-jest
+            script: test:no-watch
     defaults:
       run:
         working-directory: ./packages/${{ matrix.package }}
@@ -27,4 +42,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build
-    - run: npm run test:no-watch
+    - run: npm run ${{ matrix.script }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,23 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # všechny dimenze v `include` jinak GA zmerguje rows do jedné combinace
+      # ironbean: per TS target a class-field emit (useDefineForClassFields),
+      # ostatní balíčky mají vlastní jednotný test:no-watch
       matrix:
-        node-version: [16.x]
-        # ironbean: per TS target a class-field emit (useDefineForClassFields),
-        # ostatní balíčky mají vlastní jednotný test:no-watch
         include:
-          - package: ironbean
-            script: test:es5
-          - package: ironbean
-            script: test:es6
-          - package: ironbean
-            script: test:es2022
-          - package: ironbean
-            script: test:es2022-define
-          - package: ironbean-jasmine
-            script: test:no-watch
-          - package: ironbean-jest
-            script: test:no-watch
+          - {package: ironbean, script: test:es5, node-version: 16.x}
+          - {package: ironbean, script: test:es6, node-version: 16.x}
+          - {package: ironbean, script: test:es2022, node-version: 16.x}
+          - {package: ironbean, script: test:es2022-define, node-version: 16.x}
+          - {package: ironbean-jasmine, script: test:no-watch, node-version: 16.x}
+          - {package: ironbean-jest, script: test:no-watch, node-version: 16.x}
     defaults:
       run:
         working-directory: ./packages/${{ matrix.package }}

--- a/packages/ironbean/jest.config.es2022-define.js
+++ b/packages/ironbean/jest.config.es2022-define.js
@@ -1,0 +1,28 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+// ES2022 target with useDefineForClassFields: true.
+// TS emits `Object.defineProperty(this, "field", {value: void 0, ...})` for
+// every class field. The monkey-patched Object.defineProperty intercepts those
+// calls for autowired-marked fields. This is the variant SWC / modern bundlers
+// produce by default - PR #67 makes sure it works even when the engine emits
+// native class fields without going through Object.defineProperty.
+module.exports = {
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          importHelpers: true,
+          strict: false,
+          strictPropertyInitialization: false,
+          noUnusedLocals: false,
+          noImplicitAny: false,
+          noUnusedParameters: false,
+          experimentalDecorators: true,
+          emitDecoratorMetadata: true,
+          target: "ES2022",
+          useDefineForClassFields: true,
+        },
+      },
+    ],
+  },
+}

--- a/packages/ironbean/jest.config.es2022.js
+++ b/packages/ironbean/jest.config.es2022.js
@@ -1,0 +1,25 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+// ES2022 target with legacy class-field emit (useDefineForClassFields: false).
+// In this mode `field = void 0` is emitted as plain assignment - the prototype
+// setter (no-op for autowired) absorbs it; accessor on prototype remains.
+module.exports = {
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          importHelpers: true,
+          strict: false,
+          strictPropertyInitialization: false,
+          noUnusedLocals: false,
+          noImplicitAny: false,
+          noUnusedParameters: false,
+          experimentalDecorators: true,
+          emitDecoratorMetadata: true,
+          target: "ES2022",
+          useDefineForClassFields: false,
+        },
+      },
+    ],
+  },
+}

--- a/packages/ironbean/package.json
+++ b/packages/ironbean/package.json
@@ -9,7 +9,11 @@
         "build": "tsc",
         "debug": "tsc --watch",
         "test": "jest --c=jest.config.es5.js --watch",
-        "test:no-watch": "jest --c=jest.config.es5.js && jest --c=jest.config.es6.js",
+        "test:es5": "jest --c=jest.config.es5.js",
+        "test:es6": "jest --c=jest.config.es6.js",
+        "test:es2022": "jest --c=jest.config.es2022.js",
+        "test:es2022-define": "jest --c=jest.config.es2022-define.js",
+        "test:no-watch": "npm run test:es5 && npm run test:es6 && npm run test:es2022 && npm run test:es2022-define",
         "release": "publish-if-not-exists"
     },
     "repository": {


### PR DESCRIPTION
Matrix testů přes 4 jest configs pro ironbean balíček:

- ES5
- ES6 (původní)
- ES2022 + `useDefineForClassFields: false`
- ES2022 + `useDefineForClassFields: true`

`package.json` scripts: `test:es5` / `test:es6` / `test:es2022` / `test:es2022-define`. `test:no-watch` pouští všechny 4 sekvenčně.

## Souvislost s PR #67

ES2022 + `useDefineForClassFields: true` je use case, který PR #67 cílí. Na masteru bez PR #67 ukazuje matrix **27 / 81 baseline failures** na této variantě — ostatní 3 targety jsou zelené.

S PR #67 mergnutým by failures klesly na 6 / 87. Zbývající 6 failures odhalují, že fix nepokrývá `new Class()` mimo container (jen `applicationContext.getBean()` path) — viz test `new initialize autowired`.

## TODO mimo PR

Workflow `.github/workflows/tests.yml` — můj token nemá `workflow` scope, musíš updatnout sám. Diff k aplikování:

\`\`\`yaml
strategy:
  fail-fast: false
  matrix:
    node-version: [16.x]
    include:
      - { package: ironbean, target: ES5, script: "test:es5" }
      - { package: ironbean, target: ES6, script: "test:es6" }
      - { package: ironbean, target: ES2022, script: "test:es2022" }
      - { package: ironbean, target: ES2022-useDefineForClassFields, script: "test:es2022-define" }
      - { package: ironbean-jasmine, target: default, script: "test:no-watch" }
      - { package: ironbean-jest, target: default, script: "test:no-watch" }
# ...
- run: npm run \${{ matrix.script }}
\`\`\`