### PR TITLE
Deprecate @autowired in favor of inject.lazy

### DIFF
--- a/packages/ironbean/src/autowired.ts
+++ b/packages/ironbean/src/autowired.ts
@@ -1,5 +1,14 @@
 import {createPropertyDecorator} from "./internals";
 
+/**
+ * @deprecated Does not work for code compiled with useDefineForClassFields: true
+ * (native class field shadows the prototype accessor and throws at runtime).
+ * Use inject.lazy() field initializer instead:
+ *
+ *     class Foo {
+ *         bar = inject.lazy(Bar);
+ *     }
+ */
 export const autowired = createPropertyDecorator({
     isConstant: context => context.isComponent,
     get(context) {

--- a/packages/ironbean/src/classComponent.ts
+++ b/packages/ironbean/src/classComponent.ts
@@ -1,4 +1,5 @@
 import {
+    checkShadowedProps,
     Component,
     ComponentContainer,
     ComponentType,
@@ -70,6 +71,7 @@ export class ClassComponent<T extends any> extends Component<T> {
         const params = container.getDependencyList(this.getConstructDependencyList());
         const Class = this._Class as TNormalClass<T>;
         const instance = new Class(...params);
+        checkShadowedProps(instance);
         // @ts-ignore
         Reflect.defineMetadata(constants.componentContainer, container, instance);
 

--- a/packages/ironbean/src/component.ts
+++ b/packages/ironbean/src/component.ts
@@ -1,4 +1,5 @@
 import {
+    checkShadowedProps,
     ClassComponent,
     CollectionComponent,
     CollectionToken,
@@ -144,6 +145,7 @@ export class Factory<T> implements IConstructable<T> {
     public construct(container: ComponentContainer): Instance<T> {
         const instance = this.constructInstance(container);
         if (instance instanceof Object) {
+            checkShadowedProps(instance);
             Reflect.defineMetadata(constants.componentContainer, container, instance);
         }
 

--- a/packages/ironbean/src/index.ts
+++ b/packages/ironbean/src/index.ts
@@ -20,7 +20,8 @@ export {
     provideScope,
     lazy,
     inject,
-    createConfig
+    createConfig,
+    ironbeanSettings
 } from "./internals";
 export {
     getBaseTestingContext,

--- a/packages/ironbean/src/inject.ts
+++ b/packages/ironbean/src/inject.ts
@@ -1,10 +1,20 @@
-import {containerStorage, Dependency, LazyToken} from "./internals";
+import {ComponentContainer, containerStorage, Dependency, ironbeanSettings, LazyToken} from "./internals";
 
 export function inject<T>(dependency: Dependency<T>): T {
-    if (containerStorage.currentComponentContainer === undefined) {
-        throw new Error("Function inject is allowed in constructor of @component only.")
+    const container = containerStorage.currentComponentContainer ?? getFallbackComponentContainer();
+    if (container === undefined) {
+        throw new Error("Function inject is allowed in constructor of @component only. Set ironbeanSettings.allowInjectOutsideComponent = true to allow it in other classes.")
     }
-    return containerStorage.currentComponentContainer.getBean(dependency);
+    return container.getBean(dependency);
+}
+
+// Pro tridy mimo container (povolene pres ironbeanSettings) resolvujeme
+// ze zakladniho containeru, stejne jako to delal @autowired.
+function getFallbackComponentContainer(): ComponentContainer | undefined {
+    if (!ironbeanSettings.allowInjectOutsideComponent) {
+        return undefined;
+    }
+    return new ComponentContainer(containerStorage.getOrCreateBaseContainer());
 }
 
 inject.lazy = function<T>(dependency: Dependency<T>): T {

--- a/packages/ironbean/src/internals.ts
+++ b/packages/ironbean/src/internals.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+export * from './settings';
 export * from './instance';
 export * from "./enums";
 export * from './lazy';

--- a/packages/ironbean/src/settings.ts
+++ b/packages/ironbean/src/settings.ts
@@ -1,0 +1,9 @@
+// Global library settings.
+export const ironbeanSettings = {
+    /**
+     * Allows inject()/inject.lazy() in classes that are not created by the container.
+     * The dependency is resolved from the base container, same as @autowired did
+     * for plain classes. Migration path from deprecated @autowired.
+     */
+    allowInjectOutsideComponent: false
+};

--- a/packages/ironbean/src/useDefClassFiedsHack.ts
+++ b/packages/ironbean/src/useDefClassFiedsHack.ts
@@ -25,3 +25,26 @@ export function markAsOverwrittenDefineProperty(o: any, p: string | number | sym
     }
     o[propOverridesSymbol].add(p);
 }
+
+// Native class fields (target ES2022+ with useDefineForClassFields: true) are defined
+// via [[DefineOwnProperty]] directly by the engine - the patched Object.defineProperty
+// above is bypassed and the own property shadows the decorator accessor on the prototype.
+// There is no way to intercept that, so fail loudly instead of returning undefined.
+export function checkShadowedProps(instance: any): void {
+    let current = Object.getPrototypeOf(instance);
+    while (current) {
+        if (current.hasOwnProperty(propOverridesSymbol)) {
+            const set: Set<string | number | symbol> = current[propOverridesSymbol];
+            set.forEach(p => {
+                const own = Object.getOwnPropertyDescriptor(instance, p);
+                // native field init creates {value, writable: true, enumerable: true, configurable: true},
+                // cached constant from the accessor creates non-writable prop - must not match
+                if (own !== undefined && own.writable === true && own.enumerable === true && own.configurable === true) {
+                    throw new Error("Property " + p.toString() + " of class " + instance.constructor.name
+                        + " is shadowed by class field, @autowired does not work for code compiled with useDefineForClassFields: true, use inject.lazy() instead.");
+                }
+            });
+        }
+        current = Object.getPrototypeOf(current);
+    }
+}

--- a/packages/ironbean/src/zaop.ts
+++ b/packages/ironbean/src/zaop.ts
@@ -1,5 +1,6 @@
 import {
     ApplicationContext,
+    checkShadowedProps,
     CollectionToken,
     Component,
     ComponentContainer,
@@ -234,6 +235,7 @@ export function createClassDecorator(settings: IClassDecoratorSettings) {
                     const componentContainer = new ComponentContainer(customContainer ?? containerStorage.currentContainer ?? containerStorage.getOrCreateBaseContainer());
                     const context = new ClassDecoratorContextImpl(Class, args, componentContainer, newTarget);
                     const instance = constructor(context);
+                    checkShadowedProps(instance);
                     Reflect.defineMetadata(constants.componentContainer, componentContainer, instance);
                     return instance;
                 }

--- a/packages/ironbean/test/api.spec.ts
+++ b/packages/ironbean/test/api.spec.ts
@@ -5,11 +5,15 @@ import {
     ComponentContext,
     ComponentType, createBaseApplicationContext,
     destroyContext,
-    getBaseApplicationContext
+    getBaseApplicationContext,
+    inject
 } from "../src";
 import {Container} from "../src/container";
+import {nativeFieldEmit} from "./emitMode";
 import {containerStorage} from "../src/containerStorage";
 import {createComponentContext, IPlugin, registerPlugin} from "../src/api";
+
+const itAutowired = nativeFieldEmit ? it.skip : it;
 
 describe("api", () => {
     let applicationContext: ApplicationContext;
@@ -29,7 +33,7 @@ describe("api", () => {
         expect(applicationContext.getBean(Container).countOfDependencies()).toBe(dependenciesCount);
     }
 
-    it("createComponentContext", () => {
+    itAutowired("createComponentContext", () => {
         @component(ComponentType.Prototype)
         class a {
             test = "sa";
@@ -46,7 +50,24 @@ describe("api", () => {
         expect(applicationContext.getBean(b)).toBe(context.getBean(b));
     });
 
-    it("plugin getContextForClassInstance", () => {
+    it("createComponentContext - inject", () => {
+        @component(ComponentType.Prototype)
+        class a {
+            test = "sa";
+        }
+
+        @component
+        class b {
+            a = inject.lazy(a);
+        }
+
+        const context = createComponentContext(applicationContext);
+
+        expect(context.getBean(a)).toBe(context.getBean(a));
+        expect(applicationContext.getBean(b)).toBe(context.getBean(b));
+    });
+
+    itAutowired("plugin getContextForClassInstance", () => {
         @component
         class Plugin implements IPlugin {
             componentContext: ComponentContext;
@@ -75,7 +96,7 @@ describe("api", () => {
         expect(applicationContext.getBean(b).a).toBe(applicationContext.getBean(b).a);
     });
 
-    it("plugins for prototype storage mode", () => {
+    itAutowired("plugins for prototype storage mode", () => {
         containerStorage.dispose();
 
         applicationContext = createBaseApplicationContext();

--- a/packages/ironbean/test/emitMode.ts
+++ b/packages/ironbean/test/emitMode.ts
@@ -1,0 +1,22 @@
+import {markAsOverwrittenDefineProperty} from "../src/internals";
+
+// Detekce, jak je tento test bundle zkompilovany.
+// legacy emit: this.field = 1 projde prototype setterem -> zadna own property.
+// lowered define (ES2021 + useDefineForClassFields): Object.defineProperty call
+//   zachyti monkeypatch pro markovane props -> prevede na set -> zadna own property.
+// native emit (ES2022+ + useDefineForClassFields): [[DefineOwnProperty]] primo
+//   v enginu, neda se zachytit -> vznikne own data property, ktera zastini accessor.
+//   @autowired na tomto targetu nefunguje a knihovna hazi exception -> testy
+//   zavisle na @autowired se pod native emitem skipuji.
+export const nativeFieldEmit: boolean = (() => {
+    class Probe {
+        field = 1;
+    }
+    Object.defineProperty(Probe.prototype, "field", {
+        get() { return undefined; },
+        set() {},
+        configurable: true,
+    });
+    markAsOverwrittenDefineProperty(Probe.prototype, "field");
+    return Object.getOwnPropertyDescriptor(new Probe(), "field") !== undefined;
+})();

--- a/packages/ironbean/test/test.spec.ts
+++ b/packages/ironbean/test/test.spec.ts
@@ -18,12 +18,18 @@ import {
     take,
     type,
     inject,
-    createConfig
+    createConfig,
+    ironbeanSettings
 } from "../src";
 import {Container} from "../src/container";
 import {containerStorage} from "../src/containerStorage";
 import {CollectionToken} from "../src/collection";
 import {LazyToken} from "../src/lazy";
+import {nativeFieldEmit} from "./emitMode";
+
+// @autowired pod native field emitem (ES2022+ s useDefineForClassFields) hazi
+// exception -> originalni autowired testy se skipuji, inject varianty bezi vsude
+const itAutowired = nativeFieldEmit ? it.skip : it;
 abstract class A {
 
 }
@@ -52,7 +58,7 @@ describe("test", () => {
         expect(applicationContext.getBean(Container).countOfDependencies()).toBe(dependenciesCount);
     }
 
-    it("test 1", () => {
+    itAutowired("test 1", () => {
         @component
         class a {
             test = "sa";
@@ -108,7 +114,51 @@ describe("test", () => {
         expect(c.prototype.postConstruct).toHaveBeenCalledWith(ib2, ic1);
     });
 
-    it("test 1 types", () => {
+    it("test 1 - inject", () => {
+        @component
+        class a {
+            test = "sa";
+        }
+
+        @component
+        class b {
+            a = inject.lazy(a);
+        }
+
+        expectDependenciesCount(2);
+        const ib1 = applicationContext.getBean(b);
+        const ib2 = applicationContext.getBean(b);
+        const ia1 = applicationContext.getBean(a);
+        const ia2 = applicationContext.getBean(a);
+
+        expect(ib1).toBe(ib2);
+        expect(ia1).toBe(ia2);
+
+        // lazy proxy neni raw instance, identitu overujeme pres sdileny stav
+        expect(ib1.a.test).toBe("sa");
+        ia1.test = "modified";
+        expect(ib1.a.test).toBe("modified");
+
+        @component
+        class c {
+            constructor(a: a) {
+                expect(a).toBe(ia1);
+            }
+
+            @postConstruct
+            postConstruct(b: b, c: c) {
+                expect(b).toBe(ib1);
+                expect(c).toBe(this);
+            }
+        }
+        jest.spyOn(c.prototype, "postConstruct");
+        const ic1 = applicationContext.getBean(c);
+
+        expect(c.prototype.postConstruct).toHaveBeenCalledTimes(1);
+        expect(c.prototype.postConstruct).toHaveBeenCalledWith(ib2, ic1);
+    });
+
+    itAutowired("test 1 types", () => {
         @component
         class a {
             test = "sa";
@@ -165,7 +215,7 @@ describe("test", () => {
         expect(c.prototype.postConstruct).toHaveBeenCalledWith(ib2, ic1);
     });
 
-    it("test 2 types", () => {
+    itAutowired("test 2 types", () => {
         @component
         class a {
             test = "sa";
@@ -281,7 +331,7 @@ describe("test", () => {
         }).toThrowError("Dependency token is not for create instance over new.");
     });
 
-    it("inject by class key class return of factory", () => {
+    itAutowired("inject by class key class return of factory", () => {
         class Cisilko extends DependencyToken.Number {}
         let i = 0;
 
@@ -324,7 +374,33 @@ describe("test", () => {
         }).toThrowError("Function inject is allowed in constructor of @component only.")
     });
 
-    it("inject by dependency token String", () => {
+    it("inject outside component allowed by settings", () => {
+        @component
+        class A {
+            test = "sa";
+        }
+
+        class B {
+            a = inject.lazy(A);
+        }
+
+        ironbeanSettings.allowInjectOutsideComponent = true;
+        try {
+            const b = new B();
+            // resolvuje se ze zakladniho containeru - stejny singleton jako getBean
+            expect(b.a.test).toBe("sa");
+            applicationContext.getBean(A).test = "zmena";
+            expect(b.a.test).toBe("zmena");
+        } finally {
+            ironbeanSettings.allowInjectOutsideComponent = false;
+        }
+
+        expect(() => {
+            new B();
+        }).toThrowError("Function inject is allowed in constructor of @component only.");
+    });
+
+    itAutowired("inject by dependency token String", () => {
         class Retizek extends DependencyToken.String {}
 
         @component
@@ -339,7 +415,21 @@ describe("test", () => {
         expect(applicationContext.getBean(A).num).toBe("retizek");
     });
 
-    it("inject by dependency token bool", () => {
+    it("inject by dependency token String - inject", () => {
+        class Retizek extends DependencyToken.String {}
+
+        @component
+        class A {
+            num = inject(Retizek);
+        }
+
+        take(Retizek).setFactory(() => "retizek");
+        expect(applicationContext.getBean(Retizek)).toBe("retizek");
+        expect(applicationContext.getBean(A).num).toBe("retizek");
+        expect(applicationContext.getBean(A).num).toBe("retizek");
+    });
+
+    itAutowired("inject by dependency token bool", () => {
         class Retizek extends DependencyToken.Boolean {}
 
         @component
@@ -354,7 +444,21 @@ describe("test", () => {
         expect(applicationContext.getBean(A).num).toBe(true);
     });
 
-    it("inject by dependency token Array", () => {
+    it("inject by dependency token bool - inject", () => {
+        class Retizek extends DependencyToken.Boolean {}
+
+        @component
+        class A {
+            num = inject(Retizek);
+        }
+
+        take(Retizek).setFactory(() => true);
+        expect(applicationContext.getBean(Retizek)).toBe(true);
+        expect(applicationContext.getBean(A).num).toBe(true);
+        expect(applicationContext.getBean(A).num).toBe(true);
+    });
+
+    itAutowired("inject by dependency token Array", () => {
         class Cisilka extends DependencyToken.Array<number> {}
 
         @component
@@ -371,7 +475,21 @@ describe("test", () => {
         expect(applicationContext.getBean(A).cisilka).toEqual([1, 2]);
     });
 
-    it("inject by dependency token Map", () => {
+    it("inject by dependency token Array - inject", () => {
+        class Cisilka extends DependencyToken.Array<number> {}
+
+        @component
+        class A {
+            cisilka = inject(Cisilka);
+        }
+
+        take(Cisilka).setFactory(() => [1, 2]);
+        expect(applicationContext.getBean(Cisilka)).toEqual([1, 2]);
+        expect(applicationContext.getBean(A).cisilka).toEqual([1, 2]);
+        expect(applicationContext.getBean(A).cisilka).toEqual([1, 2]);
+    });
+
+    itAutowired("inject by dependency token Map", () => {
         class Cisilka extends DependencyToken.Map<number, number> {}
 
         @component
@@ -390,7 +508,23 @@ describe("test", () => {
         expect(applicationContext.getBean(A).cisilka).toEqual(map);
     });
 
-    it("inject by dependency token Set", () => {
+    it("inject by dependency token Map - inject", () => {
+        class Cisilka extends DependencyToken.Map<number, number> {}
+
+        @component
+        class A {
+            cisilka = inject(Cisilka);
+        }
+
+        const map = new Map<number, number>();
+
+        take(Cisilka).setFactory(() => map);
+        expect(applicationContext.getBean(Cisilka)).toEqual(map);
+        expect(applicationContext.getBean(A).cisilka).toEqual(map);
+        expect(applicationContext.getBean(A).cisilka).toEqual(map);
+    });
+
+    itAutowired("inject by dependency token Set", () => {
         class Cisilka extends DependencyToken.Set<number> {}
 
         @component
@@ -409,7 +543,23 @@ describe("test", () => {
         expect(applicationContext.getBean(A).cisilka).toEqual(set);
     });
 
-    it("test context for class created by factory", () => {
+    it("inject by dependency token Set - inject", () => {
+        class Cisilka extends DependencyToken.Set<number> {}
+
+        @component
+        class A {
+            cisilka = inject(Cisilka);
+        }
+
+        const set = new Set<number>();
+
+        take(Cisilka).setFactory(() => set);
+        expect(applicationContext.getBean(Cisilka)).toEqual(set);
+        expect(applicationContext.getBean(A).cisilka).toEqual(set);
+        expect(applicationContext.getBean(A).cisilka).toEqual(set);
+    });
+
+    itAutowired("test context for class created by factory", () => {
         @component(ComponentType.Prototype)
         class B {
 
@@ -438,6 +588,37 @@ describe("test", () => {
         expect(applicationContext.getBean(A)).toBe(applicationContext.getBean(A));
         expect(applicationContext.getBean(A).b).toBe(applicationContext.getBean(A).b);
         expect(applicationContext.getBean(A).fa).toBe(applicationContext.getBean(A).fa2);
+    });
+
+    it("test context for class created by factory - inject", () => {
+        @component(ComponentType.Prototype)
+        class B {
+
+        }
+
+        @component(ComponentType.Prototype)
+        class Fa implements IFactory<A2> {
+            create(): A2 {
+                return new A2(this);
+            }
+        }
+
+        class A2 {
+            b = inject.lazy(B);
+            fa: Fa;
+            fa2 = inject.lazy(Fa);
+
+            constructor(fa: Fa) {
+                this.fa = fa;
+            }
+        }
+
+        take(A2).setType(ComponentType.Singleton)
+        take(A2).setFactory(Fa);
+
+        expect(applicationContext.getBean(A2)).toBe(applicationContext.getBean(A2));
+        expect(applicationContext.getBean(A2).b).toBe(applicationContext.getBean(A2).b);
+        expect(applicationContext.getBean(A2).fa2).toBe(applicationContext.getBean(A2).fa2);
     });
 
     it("inject by key prototype return  throw", () => {
@@ -472,7 +653,7 @@ describe("test", () => {
         expect(applicationContext.getBean(key)).toBe(2);
     });
 
-    it("lazy", () => {
+    itAutowired("lazy", () => {
         @component
         class A {
             a = 1;
@@ -537,6 +718,64 @@ describe("test", () => {
         expect(b.a.b).toBe(20);
     })
 
+    it("lazy - inject", () => {
+        @component
+        class A2 {
+            a = 1;
+            b = 10;
+            x = {};
+
+            @postConstruct
+            postconstruct() {
+
+            }
+
+            ahoj() {
+                this.bye();
+                expect(this instanceof A2).toBe(true);
+            }
+
+            getA() {
+                return this.a;
+            }
+
+            bye() {
+
+            }
+        }
+
+        const spy = jest.spyOn(A2.prototype, "postconstruct");
+
+        @component
+        class B {
+            lazyCollectionA: A2[] = inject.lazy(CollectionToken.create(A2)) as any;
+
+            constructor(@lazy public a: A2, @lazy public a2: A2) {
+            }
+        }
+
+        const b = applicationContext.getBean(B);
+        expect(spy).not.toHaveBeenCalled()
+        b.a.ahoj();
+        expect(spy).toHaveBeenCalled()
+        b.a.ahoj();
+        expect((b.a as any).shit).toBe(undefined);
+
+        expect(b.lazyCollectionA.length).toBe(1);
+
+        b.a2.ahoj();
+        expect((b.a2 as any).shit).toBe(undefined);
+
+        expect(b.a).toBe(b.a2);
+        expect(b.a.x).toBe(b.a2.x);
+
+        expect(b.a.getA()).toBe(1);
+        expect(b.a.b).toBe(10);
+
+        b.a.b = 20;
+        expect(b.a.b).toBe(20);
+    })
+
     it("when class has factory -> postConstruct have not been called", () => {
         class G {
             @postConstruct
@@ -568,7 +807,7 @@ describe("test", () => {
         applicationContext.getBean(Abstract);
     });
 
-    it("lazy autowired", () => {
+    itAutowired("lazy autowired", () => {
         @component
         class A {
             a = 1;
@@ -734,7 +973,7 @@ describe("test", () => {
         expectDependenciesCount(5);
     })
 
-    it("collection autowired", () => {
+    itAutowired("collection autowired", () => {
         @component
         class AA extends A {
 
@@ -761,6 +1000,36 @@ describe("test", () => {
         expectDependenciesCount(3);
         expect(b.collection.length).toBe(2);
         expectDependenciesCount(5);
+        expect(b.collection[0] instanceof AA).toBe(true);
+        expect(b.collection[1] instanceof AB).toBe(true);
+    });
+
+    it("collection autowired - inject", () => {
+        // vlastni base trida - originalni test binduje na sdilenou modulovou A
+        class ABase {
+
+        }
+
+        @component
+        class AA extends ABase {
+
+        }
+
+        @component
+        class AB extends ABase {
+
+        }
+
+        take(ABase).bindTo(AA);
+        take(ABase).bindTo(AB);
+
+        @component
+        class B {
+            public collection: ABase[] = inject(CollectionToken.create(ABase)) as any;
+        }
+
+        const b = applicationContext.getBean(B);
+        expect(b.collection.length).toBe(2);
         expect(b.collection[0] instanceof AA).toBe(true);
         expect(b.collection[1] instanceof AB).toBe(true);
     });
@@ -803,7 +1072,7 @@ describe("test", () => {
         expect(b.collection[1] instanceof AB).toBe(true);
     });
 
-    it("lazy collection autowired", () => {
+    itAutowired("lazy collection autowired", () => {
         class A {
             ahoj() {
 
@@ -845,6 +1114,39 @@ describe("test", () => {
         expectDependenciesCount(6);
         b.collection[1].ahoj();
         expectDependenciesCount(7);
+    });
+
+    it("lazy collection autowired - inject", () => {
+        class A2 {
+            ahoj() {
+
+            }
+        }
+
+        @component
+        class AA extends A2 {
+
+        }
+
+        @component
+        class AB extends A2 {
+
+        }
+
+        take(A2).bindTo(AA);
+        take(A2).bindTo(AB);
+
+        @component
+        class B {
+            public collection: A2[] = inject(CollectionToken.create(LazyToken.create(A2))) as any;
+        }
+
+        const b = applicationContext.getBean(B);
+        expect(b.collection.length).toBe(2);
+        expect(b.collection[0] instanceof Object).toBe(true);
+        expect(b.collection[1] instanceof Object).toBe(true);
+        b.collection[0].ahoj();
+        b.collection[1].ahoj();
     });
 
     it("collection constuctor inject", () => {
@@ -892,7 +1194,7 @@ describe("test", () => {
         expectDependenciesCount(7);
     });
 
-    it("autowired property in component is constant", () => {
+    itAutowired("autowired property in component is constant", () => {
         @component
         class C {
 
@@ -914,7 +1216,40 @@ describe("test", () => {
         expect(b.c).toBe(b.c);
         expect(Object.getOwnPropertyDescriptor(a, "c")?.value).toBe(a.c);
         expect(Object.getOwnPropertyDescriptor(b, "c")?.value).toBe(undefined);
-    })
+    });
+
+    it("autowired property in component is constant - inject", () => {
+        @component
+        class C {
+
+        }
+
+        @component
+        class A2 {
+            c = inject.lazy(C);
+        }
+
+        const a = applicationContext.getBean(A2);
+
+        expect(a.c).toBe(a.c);
+        expect(Object.getOwnPropertyDescriptor(a, "c")?.value).toBe(a.c);
+    });
+
+    (nativeFieldEmit ? it : it.skip)("autowired with native class fields throws", () => {
+        @component
+        class Aa {
+            test = "sa";
+        }
+
+        @component
+        class Bb {
+            @autowired a!: Aa;
+        }
+
+        expect(() => {
+            applicationContext.getBean(Bb);
+        }).toThrowError("Property a of class Bb is shadowed by class field, @autowired does not work for code compiled with useDefineForClassFields: true, use inject.lazy() instead.");
+    });
 
     it("circular dependency", () => {
         @component
@@ -1013,7 +1348,7 @@ describe("test", () => {
         }).toThrowError("Factory for key not found.");
     });
 
-    it("inject by key", () => {
+    itAutowired("inject by key", () => {
         const key = DependencyToken.create<string>("key");
         const key2 = DependencyToken.create<string>("key2");
         const key3 = DependencyToken.create<b>("key3");
@@ -1101,7 +1436,82 @@ describe("test", () => {
         expect(c.prototype.postConstruct).toHaveBeenCalledWith(ib2, ic1);
     });
 
-    it("scopes", () => {
+    it("inject by key - inject", () => {
+        const key = DependencyToken.create<string>("key");
+        const key2 = DependencyToken.create<string>("key2");
+        const key3 = DependencyToken.create<b>("key3");
+
+        class Item {
+            a: string;
+            constructor(a: string) {
+                this.a = a;
+            }
+        }
+
+        take(key).setFactory(() => "datata");
+        take(key2).setFactory(() => "datata22");
+        take(key3).setFactory(() => new b());
+        take(Item).setFactory((context) => new Item(context.getBean(key) + context.getBean(key2)));
+        take(Item).setType(ComponentType.Singleton);
+
+        expect(applicationContext.getBean(Item).a).toBe("datatadatata22");
+        expect(applicationContext.getBean(Item)).toBe(applicationContext.getBean(Item));
+
+        @component
+        class a {
+            test = "sa";
+
+            constructor(@type(() => key) data: string, @type(key2) data2: string) {
+                expect(data).toBe("datata");
+                expect(data2).toBe("datata22");
+            }
+
+            @postConstruct
+            post(@type(key3) data: any, item: Item) {
+                expect(data instanceof  b).toBe(true);
+                expect(item.a).toBe("datatadatata22");
+            }
+        }
+
+        @component
+        class b {
+            a = inject.lazy(a);
+            data = inject(key);
+        }
+
+        const ib1 = applicationContext.getBean(b);
+        const ib2 = applicationContext.getBean(b);
+        const ia1 = applicationContext.getBean(a);
+
+        expect(ib1.a.test).toBe("sa");
+        ia1.test = "zmena";
+        expect(ib1.a.test).toBe("zmena");
+        expect(ib1.data).toBe("datata");
+        expect(ib1).toBe(ib2);
+
+        expect(applicationContext.getBean(key)).toBe("datata");
+        expect(applicationContext.getBean(key2)).toBe("datata22");
+
+        @component
+        class c {
+            constructor(a: a) {
+                expect(a).toBe(ia1);
+            }
+
+            @postConstruct
+            postConstruct(b: b, c: c) {
+                expect(b).toBe(ib1);
+                expect(c).toBe(this);
+            }
+        }
+        jest.spyOn(c.prototype, "postConstruct")
+        const ic1 = applicationContext.getBean(c);
+
+        expect(c.prototype.postConstruct).toHaveBeenCalledTimes(1);
+        expect(c.prototype.postConstruct).toHaveBeenCalledWith(ib2, ic1);
+    });
+
+    itAutowired("scopes", () => {
         @component
         class a {
             test = "sa";
@@ -1206,6 +1616,72 @@ describe("test", () => {
         expect(c.prototype.postConstruct).toHaveBeenCalledWith(ib2, ic1);
     });
 
+    it("scopes - inject", () => {
+        @component
+        class a {
+            test = "sa";
+        }
+
+        @component
+        class b {
+            a = inject.lazy(a);
+        }
+
+        const ticket = Scope.create("ticket");
+        const token = DependencyToken.create<Ticket>("token", {scope: ticket});
+
+        take(token).setFactory((ctx) => ctx.getBean(Ticket));
+
+        @component
+        @scope(ticket)
+        class Ticket {
+            idTicket: number = 10;
+
+            applicationContext = inject(ApplicationContext);
+
+            token = inject.lazy(token);
+
+            constructor(context: ApplicationContext) {
+                expect(context).not.toBe(applicationContext);
+                expect(context.getBean(TicketData)).toBe(context.getBean(TicketData));
+                // eager inject vraci primo bean, identita sedi i v konstruktoru
+                expect(context).toBe(this.applicationContext);
+            }
+
+            @postConstruct
+            post(context: ApplicationContext) {
+                expect(context).not.toBe(applicationContext);
+                expect(context.getBean(TicketData)).toBe(context.getBean(TicketData));
+                expect(context).toBe(this.applicationContext);
+                // lazy proxy neni raw instance, identitu overujeme pres sdileny stav
+                this.idTicket = 11;
+                expect(this.token.idTicket).toBe(11);
+                this.idTicket = 10;
+            }
+        }
+
+        @component
+        @scope(ticket)
+        class TicketData {
+            name: string = "name";
+        }
+
+        const ib1 = applicationContext.getBean(b);
+        const ia1 = applicationContext.getBean(a);
+        const ticket1 = applicationContext.createOrGetParentContext(ticket).getBean(Ticket);
+        const ticket2 = applicationContext.createOrGetParentContext(ticket).getBean(Ticket);
+        expect(() => {
+            applicationContext.getBean(Ticket);
+        }).toThrowError("I can't create a container for (Class Ticket) for scope (DEFAULT.ticket), Please use createOrGetParentContext for manual creation.");
+
+        ia1.test = "zmena";
+        expect(ib1.a.test).toBe("zmena");
+
+        expect(ticket1.idTicket).toBe(10);
+        expect(ticket2.idTicket).toBe(10);
+        expect(ticket1).not.toBe(ticket2);
+    });
+
     it("scope isParent", () => {
         const def = Scope.getDefault();
         const a = Scope.create("a");
@@ -1224,7 +1700,7 @@ describe("test", () => {
         expect(b.isParent(def)).toBe(true);
     });
 
-    it("scopes combo", () => {
+    itAutowired("scopes combo", () => {
         const s1 = Scope.create("1");
         const s2 = s1.createScope("2");
 
@@ -1255,6 +1731,42 @@ describe("test", () => {
         const b = context2.getBean(B);
         expect(a).toBe(context1.getBean(A));
         expect(b.a).toBe(context2.getBean(A));
+    })
+
+    it("scopes combo - inject", () => {
+        const s1 = Scope.create("1");
+        const s2 = s1.createScope("2");
+
+        const token = DependencyToken.create("token");
+        take(token).setFactory(() => 1);
+        take(token).setType(ComponentType.Singleton);
+
+        @component
+        @scope(s1)
+        class A {
+            c = inject(ApplicationContext);
+        }
+
+        @component
+        @scope(s2)
+        class B {
+            a = inject.lazy(A);
+            token = inject(token);
+            constructor(a: A, context: ApplicationContext) {
+                expect(a.c).not.toBe(context);
+                // eager inject - hodnota je k dispozici uz v konstruktoru
+                expect(this.token).toBe(1);
+            }
+        }
+
+        const context1 = applicationContext.createOrGetParentContext(s1);
+        const context2 = applicationContext.createOrGetParentContext(s2);
+        const a = context1.getBean(A);
+        const b = context2.getBean(B);
+        expect(a).toBe(context1.getBean(A));
+        // lazy proxy neni raw instance, vede ale na stejny bean jako getBean v context2
+        (context2.getBean(A) as any).marker = 1;
+        expect((b.a as any).marker).toBe(1);
     })
 
     describe("need scope", () => {
@@ -1317,6 +1829,93 @@ describe("test", () => {
            expect(() => {
                const b = new B(10);
            }).toThrowError("Class B must be initialized via [provideScope] DEFAULT.scopeName.");
+        });
+
+        itAutowired("correct using", () => {
+            const scopeContext = applicationContext.createOrGetParentContext(scope1).getBean(Help).context;
+
+            const a = scopeContext.provideScope(() => new A())
+            const b = scopeContext.provideScope(() => new B(11))
+
+            expect(a.test()).toBe("text");
+            a.test = () => "shit";
+            expect(a.test()).toBe("shit");
+            expect(b.test()).toBe("text");
+            expect(b.borec).toBe(11);
+
+            expect(a instanceof A).toBe(true);
+            expect(b instanceof A).toBe(true);
+            expect(b instanceof B).toBe(true);
+
+            expect(a.context).toBe(scopeContext);
+            expect(b.context).toBe(scopeContext);
+        });
+
+        itAutowired("correct using provide decorator", () => {
+            const help = applicationContext.createOrGetParentContext(scope1).getBean(Help);
+            const scopeContext = help.context;
+            const b = help.providuj(111);
+
+            expect(b.context).toBe(scopeContext);
+            expect(b.borec).toBe(111);
+        });
+    });
+
+    describe("need scope - inject", () => {
+        const scope1 = Scope.create("scopeNameInject");
+
+        @needScope(scope1)
+        class A {
+           context = inject(ApplicationContext);
+
+           public test() {
+               return "text";
+           }
+        }
+
+        @needScope(scope1)
+        class B extends A {
+            public borec: number;
+            constructor(borec: number) {
+                super();
+                this.borec = borec;
+            }
+        }
+
+        @component
+        @scope(scope1)
+        class Help {
+           context = inject(ApplicationContext);
+
+           @provideScope
+           providuj(borec: number) {
+                expect(this.context instanceof ApplicationContext).toBe(true);
+                return new B(borec);
+           }
+        }
+
+        it("different scope provided", () => {
+            expect(() => {
+                applicationContext.provideScope(() => {
+                    new A();
+                });
+            }).toThrowError("Class A initialized with different scope provided, please provide scope DEFAULT.scopeNameInject.");
+
+            expect(() => {
+                applicationContext.provideScope(() => {
+                    new B(10);
+                });
+            }).toThrowError("Class B initialized with different scope provided, please provide scope DEFAULT.scopeNameInject.");
+        });
+
+        it("ust be initialized via provideScope", () => {
+           expect(() => {
+               new A();
+           }).toThrowError("Class A must be initialized via [provideScope] DEFAULT.scopeNameInject.");
+
+           expect(() => {
+               new B(10);
+           }).toThrowError("Class B must be initialized via [provideScope] DEFAULT.scopeNameInject.");
         });
 
         it("correct using", () => {
@@ -1396,7 +1995,7 @@ describe("test", () => {
             }
         }
 
-        it("missing type", () => {
+        itAutowired("missing type", () => {
             @component
             class A {
                 @autowired
@@ -1411,7 +2010,7 @@ describe("test", () => {
             }).toThrowError("Property item of class A failed to determine type.")
         });
 
-        it("test1", () => {
+        itAutowired("test1", () => {
             let context = getBaseApplicationContext();
             const oldB = context.getBean(AComponent).b;
             const oldC = context.getBean(AComponent).c;
@@ -1437,7 +2036,7 @@ describe("test", () => {
             expect(context.getBean(C)).not.toBe(oldC);
         });
 
-        it("new initialize autowired", () => {
+        itAutowired("new initialize autowired", () => {
             class A2 {
                 @autowired b!: B;
                 @autowired c!: C;
@@ -1485,6 +2084,75 @@ describe("test", () => {
         })
     });
 
+    describe("autowired tests - inject", () => {
+        @component
+        class B {
+
+        }
+
+        @component(ComponentType.Prototype)
+        class C {
+
+        }
+
+        @component(ComponentType.Prototype)
+        class D {
+
+        }
+
+        take(D).setFactory(component(class DFactory implements IFactory<D>{
+            create(): D {
+                return new D();
+            }
+        }))
+
+        @component
+        class A {
+            b = inject.lazy(B);
+            c = inject.lazy(C);
+            c2 = inject.lazy(C);
+            d = inject.lazy(D);
+        }
+
+        @component
+        class AComponent extends A {
+            c3: C;
+            c4!: C;
+
+            constructor(c3: C, context: ComponentContext) {
+                super();
+                this.c3 = c3;
+                expect(context.getBean(C)).toBe(c3);
+            }
+
+            @postConstruct
+            post(c4: C) {
+                this.c4 = c4;
+            }
+        }
+
+        it("test1", () => {
+            const context = getBaseApplicationContext();
+            const ac = context.getBean(AComponent);
+
+            expect(ac.b).toBe(ac.b);
+            (ac.b as any).marker = "b";
+            expect((context.getBean(B) as any).marker).toBe("b");
+
+            // c a c2 jsou ruzne proxy, ale podkladova prototype instance C je stejna
+            (ac.c as any).marker = "c";
+            expect((ac.c2 as any).marker).toBe("c");
+            // rozdil proti autowired: inject.lazy resolvuje pres vlastni component
+            // container, ctor/postConstruct parametry maji svou prototype instanci
+            expect((ac.c3 as any).marker).toBe(undefined);
+            (ac.c3 as any).marker = "c3";
+            expect((ac.c4 as any).marker).toBe("c3");
+            expect((context.getBean(C) as any).marker).toBe(undefined);
+
+            expect(ac.d).toBe(ac.d);
+        });
+    });
+
     describe("intrfaces tests", () => {
         interface F {
             x: number;
@@ -1503,9 +2171,35 @@ describe("test", () => {
 
         take(f).bindTo(A);
 
-        it("test1", () => {
+        itAutowired("test1", () => {
             expect(applicationContext.getBean(f).x).toBe(10)
             expect(applicationContext.getBean(f).f).toBe(applicationContext.getBean(f))
+        });
+    });
+
+    describe("intrfaces tests - inject", () => {
+        interface F {
+            x: number;
+            f: F;
+        }
+        const f = DependencyToken.create<F>("fInject");
+
+        @component
+        class A implements F {
+            x: number = 10;
+            h: number = 20;
+            f = inject.lazy(f);
+        }
+
+        take(f).bindTo(A);
+
+        it("test1", () => {
+            const inst = applicationContext.getBean(f);
+            expect(inst.x).toBe(10);
+            // self-reference pres lazy proxy - vede na stejny singleton
+            (inst as any).marker = 1;
+            expect((inst.f as any).marker).toBe(1);
+            expect(inst.f.x).toBe(10);
         });
     });
 

--- a/packages/ironbean/test/testing.spec.ts
+++ b/packages/ironbean/test/testing.spec.ts
@@ -16,7 +16,11 @@ import {
     type
 } from "../src";
 import {Container} from "../src/container";
+import {nativeFieldEmit} from "./emitMode";
 import {TestProvider} from "../src/api";
+
+// @autowired pod native field emitem hazi exception -> originaly se skipuji
+const itAutowired = nativeFieldEmit ? it.skip : it;
 
 describe("testing", () => {
     let testingContext: TestingContext;
@@ -34,7 +38,7 @@ describe("testing", () => {
         expect(testingContext.getBean(Container).countOfDependencies()).toBe(dependenciesCount + 1);
     }
 
-    it("inject by key", () => {
+    itAutowired("inject by key", () => {
         const key = DependencyToken.create<string>("key");
         const key2 = DependencyToken.create<string>("key2");
         const key3 = DependencyToken.create<b>("key3");
@@ -91,6 +95,82 @@ describe("testing", () => {
         expect(ia1).toBe(ia2);
         expect(ia1).toBe(ia3);
         expect(ia1).toBe(ia4);
+
+        expect(testingContext.getBean(key)).toBe(testingContext.getBean(key));
+        expect(testingContext.getBean(key2)).toBe(testingContext.getBean(key2));
+
+        testingContext.getMock(a).getText = () => "ahoja";
+
+        @component
+        class c {
+            constructor(a: a) {
+                expect(a).toBe(ia1);
+                jest.spyOn(a, "f");
+                expect(a.f).not.toHaveBeenCalled();
+                a.f();
+                expect(a.getText()).toBe("ahoja");
+                expect(a.f).toHaveBeenCalled();
+            }
+
+            @postConstruct
+            postConstruct(b: b, c: c) {
+                expect(b).toBe(ib1);
+                expect(c).toBe(this);
+            }
+        }
+        jest.spyOn(c.prototype, "postConstruct");
+
+        const ic1 = testingContext.getBeanWithMocks(c);
+        expect(c.prototype.postConstruct).toHaveBeenCalledTimes(1);
+        expect(c.prototype.postConstruct).toHaveBeenCalledWith(ib2, ic1);
+
+    });
+
+    it("inject by key - inject", () => {
+        const key = DependencyToken.create<string>("key");
+        const key2 = DependencyToken.create<string>("key2");
+        const key3 = DependencyToken.create<b>("key3");
+
+        take(key).setFactory(() => "datata");
+        take(key2).setFactory(() => "datata22");
+        take(key3).setFactory(() => new b());
+
+        @component
+        class a {
+            test = "sa";
+
+            constructor(@type(key) data: string, @type(key2) data2: string) {
+                expect(data).toBe("datata");
+                expect(data2).toBe("datata22");
+            }
+
+            @postConstruct
+            post(@type(key3) data: any) {
+                expect(data instanceof b).toBe(true);
+            }
+
+            f() {
+
+            }
+
+            getText() {
+                return "ahoj1";
+            }
+        }
+
+        @component
+        class b {
+            a = inject.lazy(a);
+            data = inject(key);
+        }
+
+        const ib1 = testingContext.getBean(b);
+        const ib2 = testingContext.getBean(b);
+        const ia1 = testingContext.getBean(a);
+        const ia2 = testingContext.getBean(a);
+
+        expect(ib1).toBe(ib2);
+        expect(ia1).toBe(ia2);
 
         expect(testingContext.getBean(key)).toBe(testingContext.getBean(key));
         expect(testingContext.getBean(key2)).toBe(testingContext.getBean(key2));
@@ -250,7 +330,7 @@ describe("testing", () => {
         expect(testingContext.getBean(A)).toBe(mock);
     })
 
-    it("test context for class created by factory", () => {
+    itAutowired("test context for class created by factory", () => {
         @component(ComponentType.Prototype)
         class B {
 
@@ -267,7 +347,24 @@ describe("testing", () => {
         expect(testingContext.getBean(A).b).toBe(testingContext.getBean(A).b);
     });
 
-    it("custom mocks", () => {
+    it("test context for class created by factory - inject", () => {
+        @component(ComponentType.Prototype)
+        class B {
+
+        }
+
+        @component
+        class A {
+            b = inject.lazy(B);
+        }
+
+        testingContext.setMockFactory(A, () => new A())
+
+        expect(testingContext.getBean(A)).toBe(testingContext.getBean(A));
+        expect(testingContext.getBean(A).b).toBe(testingContext.getBean(A).b);
+    });
+
+    itAutowired("custom mocks", () => {
 
         @component
         class a {
@@ -292,7 +389,33 @@ describe("testing", () => {
         expect(iB.a.f).toBe("moje vlastni");
     });
 
-    it("custom mocks 2", () => {
+    it("custom mocks - inject", () => {
+
+        @component
+        class a {
+            f = "ajp";
+        }
+
+        @component
+        class b {
+            a = inject.lazy(a);
+            g = "haha";
+        }
+
+        @component
+        class customA extends a {
+            f = "moje vlastni";
+            hmm =  10;
+        }
+
+        testingContext.setMock(a, customA);
+
+        const iB = testingContext.getBeanWithMocks(b);
+        // inject.lazy resolvuje pres testing container -> dostane mock
+        expect(iB.a.f).toBe("moje vlastni");
+    });
+
+    itAutowired("custom mocks 2", () => {
 
         @component
         class a {
@@ -306,6 +429,34 @@ describe("testing", () => {
         }
 
         const becko = DependencyToken.create<b>("becko");
+        take(becko).bindTo(b);
+
+        @component
+        class customA extends a {
+            f = "moje vlastni";
+            hmm =  10;
+        }
+
+        testingContext.setMock(a, customA);
+
+        const iB = testingContext.getBeanWithMocks(becko);
+        expect(iB.a.f).toBe("moje vlastni");
+    });
+
+    it("custom mocks 2 - inject", () => {
+
+        @component
+        class a {
+            f = "ajp";
+        }
+
+        @component
+        class b {
+            a = inject.lazy(a);
+            g = "haha";
+        }
+
+        const becko = DependencyToken.create<b>("beckoInject");
         take(becko).bindTo(b);
 
         @component
@@ -334,7 +485,7 @@ describe("testing", () => {
         }).toThrowError("Mock factory Class B for dependency Class A must be @component.")
     });
 
-    it("mock for dependendcy token null", () => {
+    itAutowired("mock for dependendcy token null", () => {
         const token = DependencyToken.create<number|null>("token");
 
         testingContext.setMockFactory(token, () => null);
@@ -343,6 +494,27 @@ describe("testing", () => {
             @autowired
             @type(token)
             a!: null;
+        }
+
+        @component
+        class customA extends a {
+            f = "moje vlastni";
+            hmm =  10;
+        }
+
+        testingContext.setMock(a, customA);
+
+        const iA = testingContext.getBeanWithMocks(a);
+        expect(iA.a).toBe(null);
+    });
+
+    it("mock for dependendcy token null - inject", () => {
+        const token = DependencyToken.create<number|null>("tokenInject");
+
+        testingContext.setMockFactory(token, () => null);
+        @component
+        class a {
+            a = inject(token);
         }
 
         @component
@@ -415,7 +587,7 @@ describe("testing", () => {
     });
 
 
-    it("inject by class key class return of factory", () => {
+    itAutowired("inject by class key class return of factory", () => {
         class Cisilko extends DependencyToken.Number {}
         let i = 0;
 
@@ -429,7 +601,20 @@ describe("testing", () => {
         expect(testingContext.getBean(Cisilko)).toBe(1);
     });
 
-    it("inject by dependency token String", () => {
+    it("inject by class key class return of factory - inject", () => {
+        class Cisilko extends DependencyToken.Number {}
+        let i = 0;
+
+        @component
+        class A {
+            num = inject(Cisilko);
+        }
+
+        take(Cisilko).setFactory(() => i++);
+        expect(testingContext.getBean(Cisilko)).toBe(1);
+    });
+
+    itAutowired("inject by dependency token String", () => {
         class Retizek extends DependencyToken.String {}
 
         @component
@@ -442,7 +627,19 @@ describe("testing", () => {
         expect(testingContext.getBean(Retizek)).toBe("string");
     });
 
-    it("inject by dependency token bool", () => {
+    it("inject by dependency token String - inject", () => {
+        class Retizek extends DependencyToken.String {}
+
+        @component
+        class A {
+            num = inject(Retizek);
+        }
+
+        take(Retizek).setFactory(() => "retizek");
+        expect(testingContext.getBean(Retizek)).toBe("string");
+    });
+
+    itAutowired("inject by dependency token bool", () => {
         class Retizek extends DependencyToken.Boolean {}
 
         @component
@@ -455,7 +652,19 @@ describe("testing", () => {
         expect(testingContext.getBean(Retizek)).toBe(true);
     });
 
-    it("inject by dependency token Array", () => {
+    it("inject by dependency token bool - inject", () => {
+        class Retizek extends DependencyToken.Boolean {}
+
+        @component
+        class A {
+            num = inject(Retizek);
+        }
+
+        take(Retizek).setFactory(() => true);
+        expect(testingContext.getBean(Retizek)).toBe(true);
+    });
+
+    itAutowired("inject by dependency token Array", () => {
         class Cisilka extends DependencyToken.Array<number> {}
 
         @component
@@ -468,7 +677,19 @@ describe("testing", () => {
         expect(testingContext.getBean(Cisilka)).toEqual([]);
     });
 
-    it("inject by dependency token Map", () => {
+    it("inject by dependency token Array - inject", () => {
+        class Cisilka extends DependencyToken.Array<number> {}
+
+        @component
+        class A {
+            cisilka = inject(Cisilka);
+        }
+
+        take(Cisilka).setFactory(() => [1, 2]);
+        expect(testingContext.getBean(Cisilka)).toEqual([]);
+    });
+
+    itAutowired("inject by dependency token Map", () => {
         class Cisilka extends DependencyToken.Map<number, number> {}
 
         @component
@@ -483,13 +704,41 @@ describe("testing", () => {
         expect(testingContext.getBean(Cisilka)).toEqual(new Map());
     });
 
-    it("inject by dependency token Set", () => {
+    it("inject by dependency token Map - inject", () => {
+        class Cisilka extends DependencyToken.Map<number, number> {}
+
+        @component
+        class A {
+            cisilka = inject(Cisilka);
+        }
+
+        const map = new Map<number, number>();
+
+        take(Cisilka).setFactory(() => map);
+        expect(testingContext.getBean(Cisilka)).toEqual(new Map());
+    });
+
+    itAutowired("inject by dependency token Set", () => {
         class Cisilka extends DependencyToken.Set<number> {}
 
         @component
         class A {
             @autowired
             cisilka: Cisilka;
+        }
+
+        const set = new Set<number>();
+
+        take(Cisilka).setFactory(() => set);
+        expect(testingContext.getBean(Cisilka)).toEqual(new Set());
+    });
+
+    it("inject by dependency token Set - inject", () => {
+        class Cisilka extends DependencyToken.Set<number> {}
+
+        @component
+        class A {
+            cisilka = inject(Cisilka);
         }
 
         const set = new Set<number>();

--- a/packages/ironbean/test/zaop.spec.ts
+++ b/packages/ironbean/test/zaop.spec.ts
@@ -1,5 +1,9 @@
 import {ApplicationContext, component, destroyContext, getBaseApplicationContext} from "../src";
 import {createPropertyDecorator} from "../src/zaop";
+import {nativeFieldEmit} from "./emitMode";
+
+// property dekoratory pod native field emitem nefunguji (own property zastini accessor)
+const itAutowired = nativeFieldEmit ? it.skip : it;
 
 describe("zaop", () => {
     let applicationContext: ApplicationContext;
@@ -13,7 +17,7 @@ describe("zaop", () => {
     });
 
     describe("property", () => {
-        it("constant", () => {
+        itAutowired("constant", () => {
             const spy = jest.fn()
             const decorator = createPropertyDecorator({
                 isConstant: true,


### PR DESCRIPTION
## Summary
- `@autowired` marked as `@deprecated` - it cannot work for code compiled with `useDefineForClassFields: true`. Native class fields are defined via `[[DefineOwnProperty]]` directly by the engine, the own property shadows the prototype accessor installed by the decorator and there is no runtime way to intercept it.
- instead of silently returning `undefined`, the container now throws: `Property a of class Bb is shadowed by class field, @autowired does not work for code compiled with useDefineForClassFields: true, use inject.lazy() instead.`
- new `ironbeanSettings.allowInjectOutsideComponent` - migration path for projects using `@autowired` in classes that are not `@component` (resolves from the base container, same as autowired did)
- every autowired test duplicated with an `inject.lazy` variant, running on all matrix targets including `es2022-define`

## Changes
**src**
- `useDefClassFiedsHack.ts` - `checkShadowedProps()` walks marked props and throws when an own property in field-init shape shadows the accessor (cached constants from the getter have a non-writable descriptor and never match)
- `classComponent.ts`, `component.ts`, `zaop.ts` - check called after construction in `ClassComponent.construct`, `Factory.construct` and the `createClassDecorator` construct trap
- `autowired.ts` - `@deprecated` JSDoc, propagates to `dist` typings
- `inject.ts`, `settings.ts` - `ironbeanSettings.allowInjectOutsideComponent` fallback to the base container, error message mentions the setting

**test**
- `emitMode.ts` - runtime detection of native field emit (probe class with a marked accessor; correctly returns false for the lowered `Object.defineProperty` emit which the monkeypatch intercepts)
- autowired tests skipped under native field emit via `itAutowired`, ~25 `\"... - inject\"` duplicates run everywhere

## Behavior differences of inject.lazy (encoded in tests)
- lazy proxy is not the raw bean - no `toBe`/`instanceof` against `getBean()` results, underlying instance is the same
- prototype components: `inject.lazy` resolves through its own component container, so constructor params get a different instance than the field (autowired shared it)
- `inject` outside `@component` throws unless `ironbeanSettings.allowInjectOutsideComponent` is enabled
- plugin `getContextForClassInstance` is bypassed by inject - the two plugin tests in `api.spec.ts` have no inject variant

## Test plan
- [x] `test:es5`, `test:es6`, `test:es2022` - 114 passed, 1 skipped (native-only exception test)
- [x] `test:es2022-define` - 76 passed, 39 skipped (autowired originals)
- [x] `tsc` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)